### PR TITLE
fix: output for tool command to also contain error output

### DIFF
--- a/app/Commands/ToolCommand.php
+++ b/app/Commands/ToolCommand.php
@@ -119,7 +119,8 @@ abstract class ToolCommand extends Command
             }
         } else {
             $taskSuccess = true;
-            $output = $process->getOutput();
+            $output = $process->getErrorOutput();
+            $output .= $process->getOutput();
         }
 
         $this->newLine();

--- a/tests/Feature/FixCommandTest.php
+++ b/tests/Feature/FixCommandTest.php
@@ -16,12 +16,12 @@ afterEach(function() {
 
 it('works', function () {
     $this->artisan('fix')
-        ->expectsOutputToContain('Fixed all files')
+        ->expectsOutputToContain('stickee')
         ->assertExitCode(0);
 });
 
 it('allows passing options', function () {
-    $this->artisan('fix --dry-run')
-        ->expectsOutputToContain('Checked all files')
+    $this->artisan('fix -- --dry-run --verbose')
+        ->expectsOutputToContain('Legend:')
         ->assertExitCode(0);
 });


### PR DESCRIPTION
PHP CS Fixer doesn't _always_ output something afterwards (for some reason) so this changes the test for the fix command to ensure it contains expected output (that is always there).

To do this I've had to change the output for a ToolCommand to also output the "error output" - which PHP CS Fixer uses to display verbose output.