### PR TITLE
fix: composer bin dir fallback by reverting earlier change

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -2,8 +2,12 @@
 
 if (! function_exists('vendor_path')) {
     function vendor_path(string $path = ''): string {
-        $vendorPath = $_composer_bin_dir ?? __DIR__ . '/../vendor/bin';
-        $vendorPath = str_replace(DIRECTORY_SEPARATOR . 'bin', '', $vendorPath);
+        if (! empty($GLOBALS['_composer_bin_dir'])) {
+            $vendorPath = $GLOBALS['_composer_bin_dir'] . DIRECTORY_SEPARATOR;
+            $vendorPath = str_replace(DIRECTORY_SEPARATOR . 'bin', '', $vendorPath);
+        } else {
+            $vendorPath = base_path(DIRECTORY_SEPARATOR . 'vendor');
+        }
 
         return $path
             ? $vendorPath . DIRECTORY_SEPARATOR . $path


### PR DESCRIPTION
this PR reverts the "fallback" part of https://github.com/stickeeuk/canary/pull/28 but keeps the minimum composer requirement