### PR TITLE
fix: PHP CS Fixer action not committing changed files

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -33,4 +33,3 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style: PHP CS Fixer"
-          file_pattern: "**/*.php"

--- a/storage/app/.github/workflows/php.yaml
+++ b/storage/app/.github/workflows/php.yaml
@@ -50,4 +50,3 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style: PHP CS Fixer"
-          file_pattern: "**/*.php"


### PR DESCRIPTION
In a project that uses Canary we had an issue with the PHP CS Fixer step not picking up files that were changed by PHP CS Fixer and this held up a release.

Since [the example in the docs for git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action#example-workflow) does not mention using globbing, and that can sometimes cause issues, I've removed it from the CI and example file included with Canary.