### PR TITLE
fix: PHP CS Fixer action finding too many changed files

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -33,3 +33,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style: PHP CS Fixer"
+          file_pattern: "**/*.php"
+          disable_globbing: true

--- a/storage/app/.github/workflows/php.yaml
+++ b/storage/app/.github/workflows/php.yaml
@@ -50,3 +50,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style: PHP CS Fixer"
+          file_pattern: "**/*.php"
+          disable_globbing: true


### PR DESCRIPTION
This PR reverts and amends https://github.com/stickeeuk/canary/pull/33 because it started to find too many files, such as temporary docker files that are produced by GitHub Actions.

Following the advice from [the docs](https://github.com/stefanzweifel/git-auto-commit-action#custom-file_pattern-changed-files-but-seeing-working-tree-clean-nothing-to-commit-in-the-logs) this PR adds `disable_globbing: true` and has been tested to prove that it only commits changed PHP files.

