### PR TITLE
ci: stop testing on MacOS

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, ]
         php: [ 8.1, ]
 
     name: PHP v${{ matrix.php }} - ${{ matrix.os }}


### PR DESCRIPTION
MacOS testing [costs too much](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers) for what we need it for.