### PR TITLE
feat: Custom command-specific options

### DIFF
--- a/app/Commands/AnalyseCommand.php
+++ b/app/Commands/AnalyseCommand.php
@@ -17,4 +17,12 @@ class AnalyseCommand extends ToolCommand
     protected string $toolName = 'phpstan';
 
     protected string $command = 'analyse';
+
+    /** @inheritDoc */
+    protected function commandSpecificOptions(): array
+    {
+        return [
+            '--xdebug',
+        ];
+    }
 }

--- a/app/Commands/ToolCommand.php
+++ b/app/Commands/ToolCommand.php
@@ -40,7 +40,10 @@ abstract class ToolCommand extends Command
             [$this->toolPath(), $this->command],
             $this->commandOptions,
             $args,
-            $this->getDynamicOptions()
+            array_unique([
+                ...$this->getDynamicOptions(),
+                ...$this->commandSpecificOptions(),
+            ]),
         );
 
         /*
@@ -82,6 +85,16 @@ abstract class ToolCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * Returns additional options to be passed into a command, specific to that particular command.
+     *
+     * @return array<int, string>
+     */
+    protected function commandSpecificOptions(): array
+    {
+        return [];
     }
 
     protected function taskReportsFailure(Process $process): bool

--- a/tests/Feature/AnalyseCommandTest.php
+++ b/tests/Feature/AnalyseCommandTest.php
@@ -13,3 +13,13 @@ it('allows passing options', function () {
         ->expectsOutputToContain('Display help for the given command')
         ->assertExitCode(0);
 });
+
+it('will prevent performance issues around xdebug by passing in a specific option', function (): void {
+    if (! extension_loaded('xdebug')) {
+        $this::markTestSkipped('Xdebug is not installed or activated!');
+    }
+
+    $this
+        ->artisan('analyse')
+        ->doesntExpectOutputToContain('The Xdebug PHP extension is active, but "--xdebug" is not used');
+});


### PR DESCRIPTION
Allows commands to have their own specific options. In this case, we're adding support for injecting `--xdebug` into Phpstan so that it can disable Xdebug for performance reasons.