### PR TITLE
fix: remove xdebug option added to Analyse command

### DIFF
--- a/app/Commands/AnalyseCommand.php
+++ b/app/Commands/AnalyseCommand.php
@@ -17,12 +17,4 @@ class AnalyseCommand extends ToolCommand
     protected string $toolName = 'phpstan';
 
     protected string $command = 'analyse';
-
-    /** @inheritDoc */
-    protected function commandSpecificOptions(): array
-    {
-        return [
-            '--xdebug',
-        ];
-    }
 }

--- a/tests/Feature/AnalyseCommandTest.php
+++ b/tests/Feature/AnalyseCommandTest.php
@@ -13,13 +13,3 @@ it('allows passing options', function () {
         ->expectsOutputToContain('Display help for the given command')
         ->assertExitCode(0);
 });
-
-it('will prevent performance issues around xdebug by passing in a specific option', function (): void {
-    if (! extension_loaded('xdebug')) {
-        $this::markTestSkipped('Xdebug is not installed or activated!');
-    }
-
-    $this
-        ->artisan('analyse')
-        ->doesntExpectOutputToContain('The Xdebug PHP extension is active, but "--xdebug" is not used');
-});


### PR DESCRIPTION
confusing wording around this in the documentation meant that we added this thinking it would help
when really it enabled xdebug and slowed things down