### PR TITLE
chore: Add PHP 8.3 to test matrix.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
 
     name: PHP v${{ matrix.php }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Ensures that Canary is tested and working under PHP 8.3.