### PR TITLE
fix: namespace collision

### DIFF
--- a/app/Commands/AnalyseCommand.php
+++ b/app/Commands/AnalyseCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Commands;
+namespace Stickee\Canary\Commands;
 
 class AnalyseCommand extends ToolCommand
 {

--- a/app/Commands/FixCommand.php
+++ b/app/Commands/FixCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Commands;
+namespace Stickee\Canary\Commands;
 
 class FixCommand extends ToolCommand
 {

--- a/app/Commands/ImproveCommand.php
+++ b/app/Commands/ImproveCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Commands;
+namespace Stickee\Canary\Commands;
 
 class ImproveCommand extends ToolCommand
 {

--- a/app/Commands/InstallCommand.php
+++ b/app/Commands/InstallCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Commands;
+namespace Stickee\Canary\Commands;
 
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;

--- a/app/Commands/SuggestCommand.php
+++ b/app/Commands/SuggestCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Commands;
+namespace Stickee\Canary\Commands;
 
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;

--- a/app/Commands/ToolCommand.php
+++ b/app/Commands/ToolCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Commands;
+namespace Stickee\Canary\Commands;
 
 use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Providers;
+namespace Stickee\Canary\Providers;
 
 use Illuminate\Console\Application;
 use Illuminate\Support\ServiceProvider;

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
+            "Stickee\\Canary\\": "app/"
         },
         "files": [
             "app/helpers.php"

--- a/config/app.php
+++ b/config/app.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Providers\AppServiceProvider;
+use Stickee\Canary\Providers\AppServiceProvider;
 use Intonate\TinkerZero\TinkerZeroServiceProvider;
 
 return [

--- a/config/commands.php
+++ b/config/commands.php
@@ -56,7 +56,7 @@ return [
      */
 
     'hidden' => [
-        App\Commands\InstallCommand::class,
+        Stickee\Canary\Commands\InstallCommand::class,
         NunoMaduro\LaravelConsoleSummary\SummaryCommand::class,
         Symfony\Component\Console\Command\DumpCompletionCommand::class,
         Symfony\Component\Console\Command\HelpCommand::class,

--- a/tests/Feature/ArchitectureTest.php
+++ b/tests/Feature/ArchitectureTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Commands\InstallCommand;
-use App\Commands\ToolCommand;
+use Stickee\Canary\Commands\InstallCommand;
+use Stickee\Canary\Commands\ToolCommand;
 
 test('strict types are used in the project')
     ->expect('App')


### PR DESCRIPTION
This PR changes the primary namespace from `App` to `Stickee\Canary`.

This is because we install Canary into `./tools/canary` and Composer will autoload any PSR-4 files, causing a conflict with any files already in the `App` namespace.