### PR TITLE
feat: lock to PHPStan v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.3",
         "laravel-zero/framework": "^11.0",
         "nunomaduro/termwind": "^2.0",
-        "stickee/larastan-config": "^2.1.1",
+        "stickee/larastan-config": "2.4.0",
         "stickee/php-cs-fixer-config": "^2.4.0",
         "stickee/rector-config": "^3.0",
         "symfony/process": "^7.0"


### PR DESCRIPTION
This PR locks PHPStan to v1. After this we will target [PHPStan v2](https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants)