### PR TITLE
chore(deps): update stickee/php-cs-fixer-config to v2.9.0

### DIFF
--- a/app/Commands/InstallCommand.php
+++ b/app/Commands/InstallCommand.php
@@ -35,7 +35,7 @@ class InstallCommand extends Command
                 </div>
             HTML);
 
-        if (! $this->tasks()) {
+        if (!$this->tasks()) {
             return 1;
         }
 
@@ -51,7 +51,7 @@ class InstallCommand extends Command
 
     private function tasks(): bool
     {
-        if (! $this->ensureDestinationDirectoryExists()) {
+        if (!$this->ensureDestinationDirectoryExists()) {
             return false;
         }
 
@@ -91,13 +91,13 @@ class InstallCommand extends Command
         $success = true;
         $disk = Storage::disk('cwd');
 
-        if (! $disk->exists($this->destination)) {
+        if (!$disk->exists($this->destination)) {
             $success = false;
         }
 
         $this->task('Destination directory exists', static fn(): bool => $success);
 
-        if (! $success) {
+        if (!$success) {
             render(<<<'HTML'
                     <div class="py-1">
                         <div class="bg-red-500">The destination directory must exist to copy files to.</div>
@@ -115,7 +115,7 @@ class InstallCommand extends Command
         $disk = Storage::disk('cwd');
         $path = $this->destination . $larastanConfig;
 
-        if (! $disk->exists($path)) {
+        if (!$disk->exists($path)) {
             $this->newLine();
             $this->error('Something went wrong.');
             $this->error("Could not amend your {$larastanConfig} file.");
@@ -142,7 +142,7 @@ class InstallCommand extends Command
             $disk = Storage::disk('cwd');
             $path = $this->destination . $gitignore;
 
-            if (! $disk->exists($path)) {
+            if (!$disk->exists($path)) {
                 return false;
             }
 
@@ -156,7 +156,7 @@ class InstallCommand extends Command
             $disk->append($path, $needle);
         });
 
-        if (! $amendedGitIgnore) {
+        if (!$amendedGitIgnore) {
             $this->newLine();
             $this->error("Could not find your {$gitignore} file.");
             $this->error("Please create a {$gitignore} file or ensure you are installing into the correct directory.");

--- a/app/Commands/ToolCommand.php
+++ b/app/Commands/ToolCommand.php
@@ -30,7 +30,7 @@ abstract class ToolCommand extends Command
 
     public function handle(): int
     {
-        if (! $this->alias) {
+        if (!$this->alias) {
             $this->alias = $this->command;
         }
 
@@ -76,7 +76,7 @@ abstract class ToolCommand extends Command
             return 1;
         }
 
-        if (! $success) {
+        if (!$success) {
             return 1;
         }
 
@@ -121,7 +121,7 @@ abstract class ToolCommand extends Command
 
         $taskFailedSuccessfully = $this->taskReportsFailure($process);
 
-        if (! $process->isSuccessful() && ! $taskFailedSuccessfully) {
+        if (!$process->isSuccessful() && !$taskFailedSuccessfully) {
             $taskSuccess = false;
             $output = $process->getErrorOutput();
             $stdOut = $process->getOutput();

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-if (! function_exists('vendor_path')) {
+if (!function_exists('vendor_path')) {
     function vendor_path(string $path = ''): string
     {
-        if (! empty($GLOBALS['_composer_bin_dir'])) {
+        if (!empty($GLOBALS['_composer_bin_dir'])) {
             $vendorPath = $GLOBALS['_composer_bin_dir'] . DIRECTORY_SEPARATOR;
             $vendorPath = str_replace(DIRECTORY_SEPARATOR . 'bin', '', $vendorPath);
         } else {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laravel-zero/framework": "^11.0",
         "nunomaduro/termwind": "^2.0",
         "stickee/larastan-config": "2.4.0",
-        "stickee/php-cs-fixer-config": "^2.8.0",
+        "stickee/php-cs-fixer-config": "^2.9.0",
         "stickee/rector-config": "^3.0",
         "symfony/process": "^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laravel-zero/framework": "^11.0",
         "nunomaduro/termwind": "^2.0",
         "stickee/larastan-config": "2.4.0",
-        "stickee/php-cs-fixer-config": "^2.4.0",
+        "stickee/php-cs-fixer-config": "^2.8.0",
         "stickee/rector-config": "^3.0",
         "symfony/process": "^7.0"
     },


### PR DESCRIPTION
The updated config includes new rules from Laravel Pint and removes the space after not operators.