### PR TITLE
test: Fix broken architecture tests

### DIFF
--- a/tests/Feature/ArchitectureTest.php
+++ b/tests/Feature/ArchitectureTest.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 use Stickee\Canary\Commands\InstallCommand;
 use Stickee\Canary\Commands\ToolCommand;
 
-test('strict types are used in the project')
-    ->expect('App')
+arch()->preset()->php();
+arch()->preset()->laravel();
+arch()->preset()->security();
+
+arch()
+    ->expect('Stickee\Canary')
+    ->toUseStrictEquality()
     ->toUseStrictTypes();
 
-test('canary commands should extend the tool command class')
-    ->expect('App\Commands')
+arch('canary commands should extend the tool command class')
+    ->expect('Stickee\Canary\Commands')
     ->classes()
+    ->toHaveSuffix('Command')
     ->toExtend(ToolCommand::class)
     ->ignoring([InstallCommand::class, ToolCommand::class]);
-
-test('there are no debugging methods present in the source code')
-    ->expect(['dd', 'var_dump', 'echo', 'ray', 'die', 'exit', 'dump', 'print_r'])
-    ->not()
-    ->toBeUsed();


### PR DESCRIPTION
Back when we changed Canary's namespaces, it looks like we forgot to update the architecture test accordingly to understand the new rules, so in essence, they weren't testing much.

Since we now have Pest 3.0, we can leverage the built-in presets to do most of the heavy lifting to check that our code looks good and adheres to code style.

Additional: Happy for any changes to be suggested to the architecture rules. Note that PHP 8.4 isn't yet supported by Canary or by PHP CS Fixer without hacks.